### PR TITLE
Refresh issue

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -188,6 +188,7 @@ module.exports = {
 	// Issues
 	getCurrentIssueNumber,
 	getIssue,
+	isPR,
 
 	// labels
 	getLabels,

--- a/src/github.js
+++ b/src/github.js
@@ -9,6 +9,8 @@ function getCurrentIssueNumber() {
 	return github.context.issue.number;
 }
 
+function isPR(issue) { return "pull_request" in issue; }
+
 async function getLabels() {
 	var json = await octokit.rest.issues.listLabelsForRepo({
 		owner: github.context.repo.owner,

--- a/src/model.js
+++ b/src/model.js
@@ -67,7 +67,7 @@ async function unblockPRs(issueNumber) {
 		console.log(`  PR is blocked by ${blockingIssues}`);
 		if (!blockingIssues.includes(issueNumber)) continue;
 		console.log("  Rerunning action on PR");
-		if (isPR(pr)) await github.rerunAction(pr.number);  // only works on prs
+		if (github.isPR(pr)) await github.rerunAction(pr.number);  // only works on prs
 		else await update(pr);  // works on prs and issues
 	}
 }

--- a/src/model.js
+++ b/src/model.js
@@ -67,7 +67,8 @@ async function unblockPRs(issueNumber) {
 		console.log(`  PR is blocked by ${blockingIssues}`);
 		if (!blockingIssues.includes(issueNumber)) continue;
 		console.log("  Rerunning action on PR");
-		await github.rerunAction(pr.number);
+		if (isPR(pr)) await github.rerunAction(pr.number);  // only works on prs
+		else await update(pr);  // works on prs and issues
 	}
 }
 


### PR DESCRIPTION
Previous versions were crashing when an issue needed to be refreshed since it was running PR-specific code. Now it checks and runs PR-specific code for PRs only, and generic code for issues. 