### PR TITLE
Improved null check for missing label

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -23,7 +23,7 @@ export async function initLabel() {
 
 	// Choose label, creating it if necessary.
 	let label = preferredLabel ?? defaultLabel;
-	if (label === null) {
+	if (label == null) {
 		core.info("No label found. Creating default label.");
 		github.createLabel(utils.defaultLabel);
 		label = utils.defaultLabel;


### PR DESCRIPTION
Now it will create the missing label instead of failing. Turns out sometimes you _do_ need to use `==` and not `===`. 

Fixes #21 