### PR TITLE
⬆ Bump Nodejs to v20 from v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ branding:
   icon: "git-pull-request"
   color: "red"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'src/index.js'


### PR DESCRIPTION
Running a workflow using this action, displays an error:

> The following actions use a deprecated Node.js version and will be forced to run on node20: Levi-Lesches/blocking-issues@v2.
> For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

See issue #26

Let me know if the fix consists solely of bumping the Node.Js version number so that I can mark it as _Ready for Review_.
